### PR TITLE
Fix htmlcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 .env
+results/
 audit.csv
 audit.json

--- a/html_cs.js
+++ b/html_cs.js
@@ -7,6 +7,8 @@ var url = process.argv[2];
 // Replace with the path to the chrome executable in your file system.
 // const executablePath = '/usr/bin/google-chrome-stable';
 
+let fail = false;
+
 (async () => {
   const browser = await puppeteer.launch({
     // executablePath
@@ -21,9 +23,11 @@ var url = process.argv[2];
     // Errors result in exit 1 and are printed
     if (output.includes('Error')) {
         console.log(output);
-        process.exit(1);
+        fail = true;
     } else if (output.includes('Warning')) {
       console.log(output);
+    } else if (output.includes('done') && fail) {
+      process.exit(1);
     }
   });
 


### PR DESCRIPTION
The output from the HTML_CodeSniffer would exit 1 after the first Error. With this fix all Warnings and Errors are printed first before logging exit 1 in case of errors on the tested webpage.